### PR TITLE
Deploy file command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/tmp

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +28,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
 name = "bitflags"
@@ -32,7 +47,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc15853171b33280f5614e77f5fa4debd33f51a86c44daa4ba3d759674c561"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "uuid",
 ]
 
@@ -332,6 +347,8 @@ name = "packster-core"
 version = "0.1.0"
 dependencies = [
  "hex",
+ "lazy_static",
+ "regex",
  "serde",
 ]
 
@@ -355,6 +372,7 @@ dependencies = [
 name = "packster-test"
 version = "0.1.0"
 dependencies = [
+ "base64 0.21.0",
  "hex",
  "indoc",
  "packster-core",
@@ -411,6 +429,23 @@ checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af83e617f331cc6ae2da5443c602dfa5af81e517212d9d611a5b3ba1777b5370"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -234,6 +234,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "indexmap"

--- a/packster-cli/src/deploy_file.rs
+++ b/packster-cli/src/deploy_file.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use packster_core::{operation::{DeployRequest}, path::Absolute};
+use crate::parse::try_from_current_dir;
+
+#[derive(Args)]
+pub struct DeployFileCommand {
+    #[arg(short='p', long, value_parser=try_from_current_dir)]
+    pub package_file: Absolute<PathBuf>,
+    #[arg(short='l', long, value_parser=try_from_current_dir)]
+    pub location_directory: Absolute<PathBuf>,
+}
+
+impl From<DeployFileCommand> for DeployRequest {
+    fn from(command: DeployFileCommand) -> DeployRequest {
+        DeployRequest::new(command.package_file, command.location_directory)
+    }
+}

--- a/packster-cli/src/main.rs
+++ b/packster-cli/src/main.rs
@@ -58,7 +58,8 @@ impl CommandLine {
                         .map(
                             |op|
                             println!("Empty deployment created at : {}", op.get_request().as_path_location().as_ref().to_string_lossy())
-                        )?,
+                        )?
+                ,
                 Command::DeployFile(deploy_file_command) =>
                     Operation::new(DeployRequest::from(deploy_file_command), New)
                         .parse_package_path()?

--- a/packster-cli/src/main.rs
+++ b/packster-cli/src/main.rs
@@ -12,6 +12,7 @@ use packster_infrastructure::{
 mod parse;
 mod pack;
 mod init_location;
+mod deploy_file;
 
 pub const CRATE_VERSION: &str = env!("CARGO_PKG_VERSION");
 
@@ -39,23 +40,37 @@ impl CommandLine {
     pub fn execute(self) -> Result<()> {
         if let Some(command) = self.command {
             match command {
-                Command::Pack(pack_command) => Operation::new(pack_command.into(), New)
-                    .parse_project(&StdFileSystem, &Toml)?
-                    .generate_unique_identity(&UniqidIdentifierGenerator::default())
-                    .archive(&StdFileSystem, &TarballArchiver)?
-                    .digest(&StdFileSystem, &Sha2Digester::Sha256)?
-                    .finalize(&StdFileSystem, CRATE_VERSION)
-                    .map(
-                        |package|
-                            println!("Package created : {}", package.get_state().to_file_name())
-                    )?
+                Command::Pack(pack_command) =>
+                    Operation::new(pack_command.into(), New)
+                        .parse_project(&StdFileSystem, &Toml)?
+                        .generate_unique_identity(&UniqidIdentifierGenerator::default())
+                        .archive(&StdFileSystem, &TarballArchiver)?
+                        .digest(&StdFileSystem, &Sha2Digester::Sha256)?
+                        .finalize(&StdFileSystem, CRATE_VERSION)
+                        .map(
+                            |operation|
+                                println!("Package created : {}", operation.get_state().to_file_name())
+                        )?
                 ,
-                Command::InitLocation(init_location) => Operation::new(init_location.into(), New)
-                    .initialize_lockfile(&StdFileSystem, &Json)
-                    .map(
-                        |op|
-                        println!("Empty deployment created at : {}", op.get_request().as_location_directory().as_ref().to_string_lossy())
-                    )?
+                Command::InitLocation(init_location_command) =>
+                    Operation::new(init_location_command.into(), New)
+                        .initialize_lockfile(&StdFileSystem, &Json)
+                        .map(
+                            |op|
+                            println!("Empty deployment created at : {}", op.get_request().as_path_location().as_ref().to_string_lossy())
+                        )?,
+                Command::DeployFile(deploy_file_command) =>
+                    Operation::new(DeployRequest::from(deploy_file_command), New)
+                        .parse_package_path()?
+                        .parse_location_lockfile(&StdFileSystem, &Json)?
+                        .probe_package_not_deployed_in_location()?
+                        .validate_package_checksum(&StdFileSystem, &Sha2Digester::Sha256)?
+                        .extract_package(&StdFileSystem, &TarballArchiver)?
+                        .update_location_lockfile(&StdFileSystem, &Json)
+                        .map(|operation| {
+                            let state = operation.get_state();
+                            println!("Package {} deployed in {}", state.package.as_identifier(), state.deploy_path.as_ref().to_string_lossy())
+                        })?
             };
         }
 
@@ -66,5 +81,6 @@ impl CommandLine {
 #[derive(Subcommand)]
 enum Command {
     Pack(pack::PackCommand),
-    InitLocation(init_location::InitLocationCommand)
+    InitLocation(init_location::InitLocationCommand),
+    DeployFile(deploy_file::DeployFileCommand)
 }

--- a/packster-core/Cargo.toml
+++ b/packster-core/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features=["derive"] }
-hex = "0.4.3"
+hex = { version = "0.4.3", features=["serde"] }
 lazy_static = "1.4.0"
 regex = "1.8.1"

--- a/packster-core/Cargo.toml
+++ b/packster-core/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2021"
 [dependencies]
 serde = { version = "1.0", features=["derive"] }
 hex = "0.4.3"
+lazy_static = "1.4.0"
+regex = "1.8.1"

--- a/packster-core/src/domain.rs
+++ b/packster-core/src/domain.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::PACKAGE_EXTENSION;
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Identifier(String);
 
 impl fmt::Display for Identifier {
@@ -14,7 +14,7 @@ impl fmt::Display for Identifier {
     }
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Version(String);
 
 impl Version {
@@ -49,6 +49,7 @@ impl Project {
     }
 }
 
+#[derive(Debug)]
 pub struct Package {
     identifier: Identifier,
     version: Version,
@@ -66,6 +67,14 @@ impl Package {
         }
     }
 
+    pub fn as_identifier(&self) -> &Identifier {
+        &self.identifier
+    }
+
+    pub fn as_digest(&self) -> &[u8] {
+        &self.digest
+    }
+
     pub fn to_checksum(&self) -> String {
         hex::encode(&self.digest)
     }
@@ -81,8 +90,8 @@ impl Package {
         )
     }
 
-    pub fn from_path(path: &Path) -> Self {
-        let filename = path.file_stem().unwrap().to_str().unwrap();
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Self {
+        let filename = path.as_ref().file_stem().unwrap().to_str().unwrap();
         let mut parts = filename.split('_');
 
         let identifier = parts.next().unwrap();
@@ -122,6 +131,10 @@ impl DeployLocation {
 
     pub fn add_deployment(&mut self, deployment: Deployment) {
         self.deployments.push(deployment);
+    }
+
+    pub fn is_checksum_deployed(&self, checksum: &str) -> bool {
+        self.deployments.iter().any(|deployment| deployment.checksum == checksum)
     }
 }
 

--- a/packster-core/src/domain.rs
+++ b/packster-core/src/domain.rs
@@ -1,4 +1,4 @@
-use std::{ path::Path, fmt, str::FromStr, println };
+use std::{ path::Path, fmt, str::FromStr };
 use serde::{Deserialize, Serialize};
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/packster-core/src/domain.rs
+++ b/packster-core/src/domain.rs
@@ -2,6 +2,7 @@ use std::{ path::Path, fmt, str::FromStr };
 use serde::{Deserialize, Serialize};
 use lazy_static::lazy_static;
 use regex::Regex;
+use hex;
 
 use crate::{ Result, Error, PACKAGE_EXTENSION };
 
@@ -34,7 +35,10 @@ impl fmt::Display for Version {
 }
 
 #[derive(Serialize, Deserialize, PartialEq, Eq, Debug, Clone)]
-pub struct Checksum(Vec<u8>);
+pub struct Checksum(
+    #[serde(with = "hex")]
+    Vec<u8>
+);
 
 impl FromStr for Checksum {
     type Err = Error;
@@ -60,7 +64,6 @@ impl From<Vec<u8>> for Checksum {
         Checksum(value)
     }
 }
-
 #[derive(Deserialize)]
 pub struct Project {
     identifier: Identifier,

--- a/packster-core/src/error.rs
+++ b/packster-core/src/error.rs
@@ -14,6 +14,8 @@ pub enum Error {
     PathIsRelative(PathBuf),
     LocationPathIsNotADirectory(PathBuf),
     LocationManifestPathIsNotAFile(PathBuf),
+    PackageChecksumDoNotMatch{package_path: PathBuf, package_id: String, package_checksum: String},
+    PackageAlreadyDeployedInLocation(String)
 }
 
 impl fmt::Display for Error {
@@ -29,7 +31,15 @@ impl fmt::Display for Error {
             PathIsRelative(path) => write!(f, "Path is relative : {}", path.to_string_lossy()),
             BaseNotInPath { base, path } => write!(f, "Base \"{}\" not in path \"{}\"", base.as_ref().to_string_lossy(), path.as_ref().to_string_lossy()),
             LocationPathIsNotADirectory(path) => write!(f, "Location path exists but is not a directory {}", path.to_string_lossy()),
-            LocationManifestPathIsNotAFile(path) => write!(f, "Location manifest path exists but is not a file {}", path.to_string_lossy())
+            LocationManifestPathIsNotAFile(path) => write!(f, "Location manifest path exists but is not a file {}", path.to_string_lossy()),
+            PackageChecksumDoNotMatch{ package_path, package_id, package_checksum } => write!(
+                f,
+                "Package {} checksum {} does not match with file {}",
+                package_checksum,
+                package_id,
+                package_path.to_string_lossy()
+            ),
+            PackageAlreadyDeployedInLocation(package_id) => write!(f,"Package {package_id} already exists in location")
         }
     }
 }

--- a/packster-core/src/error.rs
+++ b/packster-core/src/error.rs
@@ -35,8 +35,8 @@ impl fmt::Display for Error {
             PackageChecksumDoNotMatch{ package_path, package_id, package_checksum } => write!(
                 f,
                 "Package {} checksum {} does not match with file {}",
-                package_checksum,
                 package_id,
+                package_checksum,
                 package_path.to_string_lossy()
             ),
             PackageAlreadyDeployedInLocation(package_id) => write!(f,"Package {package_id} already exists in location")

--- a/packster-core/src/error.rs
+++ b/packster-core/src/error.rs
@@ -15,7 +15,9 @@ pub enum Error {
     LocationPathIsNotADirectory(PathBuf),
     LocationManifestPathIsNotAFile(PathBuf),
     PackageChecksumDoNotMatch{package_path: PathBuf, package_id: String, package_checksum: String},
-    PackageAlreadyDeployedInLocation(String)
+    PackageAlreadyDeployedInLocation(String),
+    AncestorIsAFile{ancestor: PathBuf, path: PathBuf},
+    NodeAlreadyExists(PathBuf)
 }
 
 impl fmt::Display for Error {
@@ -39,7 +41,9 @@ impl fmt::Display for Error {
                 package_checksum,
                 package_path.to_string_lossy()
             ),
-            PackageAlreadyDeployedInLocation(package_id) => write!(f,"Package {package_id} already exists in location")
+            PackageAlreadyDeployedInLocation(package_id) => write!(f,"Package {package_id} already exists in location"),
+            AncestorIsAFile{ ancestor, path } => write!(f, "Ancestor {} of {} is a file", ancestor.to_string_lossy(), path.to_string_lossy()),
+            NodeAlreadyExists(path) => write!(f,"Resource {} already exists", path.to_string_lossy()),
         }
     }
 }

--- a/packster-core/src/error.rs
+++ b/packster-core/src/error.rs
@@ -1,11 +1,14 @@
 use std::{fmt,error, path::PathBuf};
 
+use hex::FromHexError;
+
 use crate::path::Absolute;
 
 #[derive(Debug)]
 pub enum Error {
     Infrastructure(Box<dyn error::Error>),
     Application(Box<dyn error::Error>),
+    HexadecimalDecodingError(FromHexError),
     ManifesPathIsADirectory(PathBuf),
     ManifestPathDoesNotExist(PathBuf),
     MissingMandatoryField { entity_name: &'static str, field_name: &'static str },
@@ -26,6 +29,7 @@ impl fmt::Display for Error {
         match self {
             Infrastructure(error) => write!(f, "Infrastructure error : {error}"),
             Application(error) => write!(f, "Application error : {error}"),
+            HexadecimalDecodingError(error) => write!(f, "Hexadecimal decoding error : {error}"),
             ManifesPathIsADirectory(path) => write!(f, "Manifest path is not a directory : {}", path.to_string_lossy()),
             ManifestPathDoesNotExist(path) => write!(f, "Manifest path does not exist : {}", path.to_string_lossy()),
             MissingMandatoryField { entity_name, field_name } => write!(f, "Missing infrastructure field {entity_name} for entity {field_name}"),
@@ -54,7 +58,12 @@ impl error::Error for Error {
         match self {
             Infrastructure(error) => Some(error.as_ref()),
             Application(error) => Some(error.as_ref()),
+            HexadecimalDecodingError(error) => Some(error),
             _ => None,
         }
     }
+}
+
+impl From<FromHexError> for Error {
+    fn from(error: FromHexError) -> Self { Error::HexadecimalDecodingError(error) }
 }

--- a/packster-core/src/lib.rs
+++ b/packster-core/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub const PACKAGE_EXTENSION : &str = "packster";
 pub const LOCKFILE_NAME : &str = "packster.lock";
+pub const PROJECT_MANIFEST_NAME : &str = "packster.toml";
 
 mod error;
 pub use error::Error;

--- a/packster-core/src/operation.rs
+++ b/packster-core/src/operation.rs
@@ -64,10 +64,6 @@ pub struct ParsedPackage<S> {
     pub package: Package
 }
 
-impl <S>AsPackage for ParsedPackage<S> {
-    fn as_package(&self) -> &Package { &self.package }
-}
-
 //Example about how to factorize common behaviors such as parsing package from path, providing an extra level of indirection
 impl <S, R: AsPackagePath>Operation<S, R> {
     pub fn parse_package_path(self) -> Result<Operation<ParsedPackage<S>, R>> {
@@ -77,6 +73,10 @@ impl <S, R: AsPackagePath>Operation<S, R> {
             ParsedPackage { state: self.state, package }
         )
     }
+}
+
+impl <S>AsPackage for ParsedPackage<S> {
+    fn as_package(&self) -> &Package { &self.package }
 }
 
 impl <S>AsLocation for ParsedPackage<ParsedLocation<S>> {
@@ -101,10 +101,6 @@ pub struct ParsedLocation<S> {
     pub location: DeployLocation
 }
 
-impl <S>AsLocation for ParsedLocation<S> {
-    fn as_location(&self) -> &DeployLocation { &self.location }
-}
-
 impl <S, R: AsPathLocation>Operation<S, R> {
     pub fn parse_location_lockfile<F: ReadOnlyFileSystem, P: Parser>(self, filesystem: &F, parser: &P) -> Result<Operation<ParsedLocation<S>, R>> {
         let lockfile_path = self.request.to_lockfile_location();
@@ -117,6 +113,10 @@ impl <S, R: AsPathLocation>Operation<S, R> {
             }
         )
     }
+}
+
+impl <S>AsLocation for ParsedLocation<S> {
+    fn as_location(&self) -> &DeployLocation { &self.location }
 }
 
 impl <S>AsPackage for ParsedLocation<ParsedPackage<S>> {

--- a/packster-core/src/operation.rs
+++ b/packster-core/src/operation.rs
@@ -131,9 +131,9 @@ pub struct NotYetDeployed<S> { pub not_yet_deployed: S }
 impl <S: AsPackage + AsLocation, R>Operation<S, R> {
     pub fn probe_package_not_deployed_in_location(self) -> Result<Operation<NotYetDeployed<S>, R>> {
         if self.state.as_location().is_checksum_deployed(self.state.as_package().as_checksum()) {
-            Self::ok_with_state(self.request, NotYetDeployed { not_yet_deployed: self.state })
-        } else {
             Err(Error::PackageAlreadyDeployedInLocation(self.state.as_package().as_identifier().to_string()))
+        } else {
+            Self::ok_with_state(self.request, NotYetDeployed { not_yet_deployed: self.state })
         }
     }
 }

--- a/packster-core/src/operation.rs
+++ b/packster-core/src/operation.rs
@@ -20,6 +20,7 @@ pub struct Operation<S, R>{
 pub struct New;
 
 //TODO doing rollback operation using same states newtype struct would be super easy and meaningful and stylish cause each state would be described as reversible, or not, or partially, or with different methods :O
+//TODO R&D : consider replace Operation by a State Trait to simplify architecture and state machine building flexibility
 impl <S, R>Operation<S, R> {
     /*Create a new operation */
     pub fn new(request: R, state: S) -> Self {

--- a/packster-core/src/operation.rs
+++ b/packster-core/src/operation.rs
@@ -130,7 +130,7 @@ pub struct NotYetDeployed<S> { pub not_yet_deployed: S }
 
 impl <S: AsPackage + AsLocation, R>Operation<S, R> {
     pub fn probe_package_not_deployed_in_location(self) -> Result<Operation<NotYetDeployed<S>, R>> {
-        if self.state.as_location().is_checksum_deployed(&self.state.as_package().to_checksum()) {
+        if self.state.as_location().is_checksum_deployed(self.state.as_package().as_checksum()) {
             Self::ok_with_state(self.request, NotYetDeployed { not_yet_deployed: self.state })
         } else {
             Err(Error::PackageAlreadyDeployedInLocation(self.state.as_package().as_identifier().to_string()))
@@ -158,14 +158,14 @@ impl <S: AsPackage, R: AsPackagePath>Operation<S, R> {
     pub fn validate_package_checksum<F: ReadOnlyFileSystem, D: Digester>(self, filesystem: &F, digester: &D) -> Result<Operation<MatchingChecksum<S>, R>> {
         let package_path = self.request.as_package_path();
         let digest = digester.generate_checksum(filesystem.open_read(&package_path)?)?;
-        if digest == self.state.as_package().as_digest() {
+        if digest == *self.state.as_package().as_checksum() {
             Self::ok_with_state(self.request, MatchingChecksum { matching_checksum: self.state })
         } else {
             Err(
                 Error::PackageChecksumDoNotMatch {
                     package_path: package_path.as_ref().to_path_buf(),
                     package_id: self.state.as_package().as_identifier().to_string(),
-                    package_checksum: self.state.as_package().to_checksum()
+                    package_checksum: self.state.as_package().as_checksum().to_string()
                 }
             )
         }

--- a/packster-core/src/operation.rs
+++ b/packster-core/src/operation.rs
@@ -1,9 +1,16 @@
 #![allow(dead_code)]
 mod pack;
+use std::path::{Path, PathBuf};
+
 pub use pack::*;
 
 mod init_location;
 pub use init_location::*;
+
+mod deploy;
+pub use deploy::*;
+
+use crate::{path::Absolute, LOCKFILE_NAME, Error, port::{ReadOnlyFileSystem, Parser, Digester}, domain::{DeployLocation, Package}, Result};
 
 pub struct Operation<S, R>{
     request: R,
@@ -36,5 +43,136 @@ impl <S, R>Operation<S, R> {
     pub (crate) fn with_request<N>(request: N, state: S) -> Operation<S, N> {
         Operation { request, state }
     }
+
+    pub (crate) fn ok_with_state<N>(request: R, state: N) -> Result<Operation<N, R>> {
+        Ok(Self::with_state(request, state))
+    }
 }
 
+//---------------------------------------------------------------------------------
+
+pub trait AsPackagePath {
+    fn as_package_path(&self) -> Absolute<&Path>;
+}
+
+pub trait AsPackage {
+    fn as_package(&self) -> &Package;
+}
+
+pub struct ParsedPackage<S> {
+    pub state: S,
+    pub package: Package
+}
+
+impl <S>AsPackage for ParsedPackage<S> {
+    fn as_package(&self) -> &Package { &self.package }
+}
+
+//Example about how to factorize common behaviors such as parsing package from path, providing an extra level of indirection
+impl <S, R: AsPackagePath>Operation<S, R> {
+    pub fn parse_package_path(self) -> Result<Operation<ParsedPackage<S>, R>> {
+        let package = Package::from_path(self.request.as_package_path()); //TODO try ?
+        Self::ok_with_state(
+            self.request,
+            ParsedPackage { state: self.state, package }
+        )
+    }
+}
+
+impl <S>AsLocation for ParsedPackage<ParsedLocation<S>> {
+    fn as_location(&self) -> &DeployLocation { &self.state.location }
+}
+
+//---------------------------------------------------------------------------------
+
+pub trait AsPathLocation {
+    fn as_path_location(&self) -> Absolute<&Path>;
+    fn to_lockfile_location(&self) -> Absolute<PathBuf> {
+        self.as_path_location().join(LOCKFILE_NAME)
+    }
+}
+
+pub trait AsLocation {
+    fn as_location(&self) -> &DeployLocation;
+}
+
+pub struct ParsedLocation<S> {
+    pub state: S,
+    pub location: DeployLocation
+}
+
+impl <S>AsLocation for ParsedLocation<S> {
+    fn as_location(&self) -> &DeployLocation { &self.location }
+}
+
+impl <S, R: AsPathLocation>Operation<S, R> {
+    pub fn parse_location_lockfile<F: ReadOnlyFileSystem, P: Parser>(self, filesystem: &F, parser: &P) -> Result<Operation<ParsedLocation<S>, R>> {
+        let lockfile_path = self.request.to_lockfile_location();
+        let lockfile_content = filesystem.read_to_string(lockfile_path)?;
+        Self::ok_with_state(
+            self.request,
+            ParsedLocation {
+                state: self.state,
+                location: parser.parse(lockfile_content)?
+            }
+        )
+    }
+}
+
+impl <S>AsPackage for ParsedLocation<ParsedPackage<S>> {
+    fn as_package(&self) -> &Package { &self.state.package }
+}
+
+//---------------------------------------------------------------------------------
+
+pub struct NotYetDeployed<S> { pub not_yet_deployed: S }
+
+impl <S: AsPackage + AsLocation, R>Operation<S, R> {
+    pub fn probe_package_not_deployed_in_location(self) -> Result<Operation<NotYetDeployed<S>, R>> {
+        if self.state.as_location().is_checksum_deployed(&self.state.as_package().to_checksum()) {
+            Self::ok_with_state(self.request, NotYetDeployed { not_yet_deployed: self.state })
+        } else {
+            Err(Error::PackageAlreadyDeployedInLocation(self.state.as_package().as_identifier().to_string()))
+        }
+    }
+}
+
+impl <S: AsPackage>AsPackage for NotYetDeployed<S> {
+    fn as_package(&self) -> &Package {
+        self.not_yet_deployed.as_package()
+    }
+}
+
+impl <S: AsLocation>AsLocation for NotYetDeployed<S> {
+    fn as_location(&self) -> &DeployLocation {
+        self.not_yet_deployed.as_location()
+    }
+}
+
+//---------------------------------------------------------------------------------
+
+pub struct MatchingChecksum<S> { pub matching_checksum: S }
+
+impl <S: AsPackage, R: AsPackagePath>Operation<S, R> {
+    pub fn validate_package_checksum<F: ReadOnlyFileSystem, D: Digester>(self, filesystem: &F, digester: &D) -> Result<Operation<MatchingChecksum<S>, R>> {
+        let package_path = self.request.as_package_path();
+        let digest = digester.generate_checksum(filesystem.open_read(&package_path)?)?;
+        if digest == self.state.as_package().as_digest() {
+            Self::ok_with_state(self.request, MatchingChecksum { matching_checksum: self.state })
+        } else {
+            Err(
+                Error::PackageChecksumDoNotMatch {
+                    package_path: package_path.as_ref().to_path_buf(),
+                    package_id: self.state.as_package().as_identifier().to_string(),
+                    package_checksum: self.state.as_package().to_checksum()
+                }
+            )
+        }
+    }
+}
+
+impl <S: AsPackage>AsPackage for MatchingChecksum<S> {
+    fn as_package(&self) -> &Package {
+        self.matching_checksum.as_package()
+    }
+}

--- a/packster-core/src/operation/deploy.rs
+++ b/packster-core/src/operation/deploy.rs
@@ -49,7 +49,11 @@ impl DeployOperation<ValidState> {
     pub fn extract_package<F: FileSystem, A: Archiver>(self, filesystem: &F, archiver: &A) -> Result<DeployOperation<ExtractedPackage>> {
         let checksum = &self.state.as_package().to_checksum();
         let deploy_path = self.request.path_location.join(checksum);
-        archiver.extract(filesystem, &self.request.path_package, &deploy_path)?;
+        archiver.extract(
+            filesystem,
+            self.request.path_package.as_absolute_path(),
+            deploy_path.as_absolute_path()
+        )?;
         Self::ok_with_state(self.request, ExtractedPackage { valid_package: self.state, deploy_path })
     }
 }

--- a/packster-core/src/operation/deploy.rs
+++ b/packster-core/src/operation/deploy.rs
@@ -47,7 +47,7 @@ pub struct ExtractedPackage {
 //An emerging good practise here : keep read operations as generic as possible and write operation as specific as possible
 impl DeployOperation<ValidState> {
     pub fn extract_package<F: FileSystem, A: Archiver>(self, filesystem: &F, archiver: &A) -> Result<DeployOperation<ExtractedPackage>> {
-        let checksum = &self.state.as_package().to_checksum();
+        let checksum = &self.state.as_package().as_checksum().to_string();
         let deploy_path = self.request.path_location.join(checksum);
         archiver.extract(
             filesystem,
@@ -66,7 +66,7 @@ pub struct DeployedPackage {
 impl DeployOperation<ExtractedPackage> {
     pub fn update_location_lockfile<F: FileSystem, Sr: Serializer>(self, filesystem: &F, serializer: &Sr) -> Result<DeployOperation<DeployedPackage>> {
         let (package, mut location) = into_package_and_location(self.state.valid_package);
-        let deployment: Deployment = Deployment::new(package.to_checksum());
+        let deployment: Deployment = Deployment::new(package.as_checksum().clone());
         location.add_deployment(deployment);
         let deploy_location_file_content = serializer.serialize(&location)?;
         filesystem.write_all(self.request.to_lockfile_location(), deploy_location_file_content.as_bytes())?;

--- a/packster-core/src/operation/deploy.rs
+++ b/packster-core/src/operation/deploy.rs
@@ -51,8 +51,8 @@ impl DeployOperation<ValidState> {
         let deploy_path = self.request.path_location.join(checksum);
         archiver.extract(
             filesystem,
-            self.request.path_package.as_absolute_path(),
-            deploy_path.as_absolute_path()
+            deploy_path.as_absolute_path(),
+            self.request.path_package.as_absolute_path()
         )?;
         Self::ok_with_state(self.request, ExtractedPackage { valid_package: self.state, deploy_path })
     }

--- a/packster-core/src/operation/deploy.rs
+++ b/packster-core/src/operation/deploy.rs
@@ -1,0 +1,72 @@
+use std::path::{Path, PathBuf};
+
+use crate::{port::{FileSystem, Archiver, Serializer}, domain::{Package, DeployLocation, Deployment}, Result, path::Absolute};
+
+use super::{Operation, New, AsPackagePath, AsPathLocation, AsPackage, ParsedPackage, ParsedLocation, NotYetDeployed, MatchingChecksum};
+
+pub struct DeployRequest {
+    path_package: Absolute<PathBuf>,
+    path_location: Absolute<PathBuf>
+}
+
+impl DeployRequest {
+    pub fn new(path_package: Absolute<PathBuf>, path_location: Absolute<PathBuf>) -> Self {
+        DeployRequest { path_package, path_location }
+    }
+}
+
+
+impl AsPackagePath for DeployRequest {
+    fn as_package_path(&self) -> Absolute<&Path> {
+        self.path_package.as_absolute_path()
+    }
+}
+
+impl AsPathLocation for DeployRequest {
+    fn as_path_location(&self) -> Absolute<&Path> {
+        self.path_location.as_absolute_path()
+    }
+}
+
+pub type DeployOperation<S> = Operation<S, DeployRequest>;
+
+type ValidState = MatchingChecksum<NotYetDeployed<ParsedLocation<ParsedPackage<New>>>>;
+
+fn as_package(valid_package: &ValidState) -> &Package {
+    valid_package.matching_checksum.not_yet_deployed.as_package()
+}
+
+fn into_package_and_location(valid_package: ValidState) -> (Package, DeployLocation) {
+    (valid_package.matching_checksum.not_yet_deployed.state.package, valid_package.matching_checksum.not_yet_deployed.location)
+}
+
+pub struct ExtractedPackage {
+    pub valid_package: ValidState,
+    pub deploy_path: Absolute<PathBuf>
+}
+
+//An emerging good practise here : keep read operations as generic as possible and write operation as specific as possible
+impl DeployOperation<ValidState> {
+    pub fn extract_package<F: FileSystem, A: Archiver>(self, filesystem: &F, archiver: &A) -> Result<DeployOperation<ExtractedPackage>> {
+        let checksum = as_package(&self.state).to_checksum();
+        let deploy_path = self.request.path_location.join(checksum);
+        archiver.extract(filesystem, &self.request.path_package, &deploy_path)?;
+        Self::ok_with_state(self.request, ExtractedPackage { valid_package: self.state, deploy_path })
+    }
+}
+
+pub struct DeployedPackage {
+    pub package: Package,
+    pub deploy_path: Absolute<PathBuf>
+}
+
+impl DeployOperation<ExtractedPackage> {
+    pub fn update_location_lockfile<F: FileSystem, Sr: Serializer>(self, filesystem: &F, serializer: &Sr) -> Result<DeployOperation<DeployedPackage>> {
+        let (package, mut location) = into_package_and_location(self.state.valid_package);
+        let deployment: Deployment = Deployment::new(package.to_checksum());
+        location.add_deployment(deployment);
+        let deploy_location_file_content = serializer.serialize(&location)?;
+        filesystem.write_all(self.request.to_lockfile_location(), deploy_location_file_content.as_bytes())?;
+        Self::ok_with_state(self.request, DeployedPackage { package, deploy_path: self.state.deploy_path })
+    }
+}

--- a/packster-core/src/operation/deploy.rs
+++ b/packster-core/src/operation/deploy.rs
@@ -32,12 +32,11 @@ pub type DeployOperation<S> = Operation<S, DeployRequest>;
 
 type ValidState = MatchingChecksum<NotYetDeployed<ParsedLocation<ParsedPackage<New>>>>;
 
-fn as_package(valid_package: &ValidState) -> &Package {
-    valid_package.matching_checksum.not_yet_deployed.as_package()
-}
-
 fn into_package_and_location(valid_package: ValidState) -> (Package, DeployLocation) {
-    (valid_package.matching_checksum.not_yet_deployed.state.package, valid_package.matching_checksum.not_yet_deployed.location)
+    (
+        valid_package.matching_checksum.not_yet_deployed.state.package,
+        valid_package.matching_checksum.not_yet_deployed.location
+    )
 }
 
 pub struct ExtractedPackage {
@@ -48,7 +47,7 @@ pub struct ExtractedPackage {
 //An emerging good practise here : keep read operations as generic as possible and write operation as specific as possible
 impl DeployOperation<ValidState> {
     pub fn extract_package<F: FileSystem, A: Archiver>(self, filesystem: &F, archiver: &A) -> Result<DeployOperation<ExtractedPackage>> {
-        let checksum = as_package(&self.state).to_checksum();
+        let checksum = &self.state.as_package().to_checksum();
         let deploy_path = self.request.path_location.join(checksum);
         archiver.extract(filesystem, &self.request.path_package, &deploy_path)?;
         Self::ok_with_state(self.request, ExtractedPackage { valid_package: self.state, deploy_path })

--- a/packster-core/src/operation/init_location.rs
+++ b/packster-core/src/operation/init_location.rs
@@ -1,7 +1,7 @@
 use std::path::{PathBuf, Path};
 
-use crate::{Result, path::Absolute, port::{ FileSystem, Serializer, Archiver }, domain::{DeployLocation, Deployment, Package},  LOCKFILE_NAME};
-use super::{Operation, New};
+use crate::{Result, path::Absolute, port::{ FileSystem, Serializer}, domain::{DeployLocation}};
+use super::{Operation, New, AsPathLocation};
 
 pub struct InitLocationRequest {
     location_directory: Absolute<PathBuf>
@@ -11,8 +11,10 @@ impl InitLocationRequest {
     pub fn new(location_directory: Absolute<PathBuf>) -> Self {
         InitLocationRequest { location_directory }
     }
+}
 
-    pub fn as_location_directory(&self) -> Absolute<&Path> {
+impl AsPathLocation for InitLocationRequest {
+    fn as_path_location(&self) -> Absolute<&Path> {
         self.location_directory.as_absolute_path()
     }
 }
@@ -25,7 +27,7 @@ pub struct LocationInitialized;
 //TODO proper error from filesystem if : lockfile is not an existing directory, and if location directory is a file
 impl InitLocationOperation<New> {
     pub fn initialize_lockfile<F: FileSystem, S: Serializer>(self, filesystem: &F, serializer: &S) -> Result<InitLocationOperation<LocationInitialized>> {
-        let lockfile_path = self.request.location_directory.as_ref().join(LOCKFILE_NAME);
+        let lockfile_path = self.request.to_lockfile_location();
 
         abort_if_something_already_present(&lockfile_path, filesystem)?;
 
@@ -38,7 +40,7 @@ impl InitLocationOperation<New> {
         let deploy_location = DeployLocation::default();
         let deploy_location_file_content = serializer.serialize(&deploy_location)?;
         filesystem.write_all(&lockfile_path, deploy_location_file_content.as_bytes())?;
-        Ok(Self::with_state(self.request, LocationInitialized))
+        Self::ok_with_state(self.request, LocationInitialized)
     }
 }
 
@@ -49,83 +51,3 @@ pub fn abort_if_something_already_present<F: FileSystem, P: AsRef<Path>>(_path: 
 
 //TODO register in a user config file ?
 //TODO handle set as default if the first location created ?
-
-
-// commande install(path du package, path de location)
-
-// extraire la checksum du package
-
-// vérifier que le package est déjà déployé dans la location sinon erreur
-// extraire le package dans la location
-
-
-pub fn install_package_to_location<P: AsRef<Path>, L: AsRef<Path>, F: FileSystem, A: Archiver, S: Serializer>(path_package: P, path_location: L, filesystem: &F, archiver: &A, serializer: &S) -> Result<()> {
-    // get checksum from package
-    let package = Package::from_path(path_package.as_ref());
-    let checksum = package.to_checksum();
-    // create deploy path from checksum to deploy package
-    let deploy_path = path_location.as_ref().join(&checksum);
-    // install package in location
-    archiver.extract(filesystem, path_package.as_ref(), deploy_path)?;
-    // get lockfile path
-    let lockfile_path = path_location.as_ref().join(LOCKFILE_NAME);
-    // append deploy location to lockfile
-
-    // todo : check if package is already installed in location
-    // todo : if yes, abort
-    // todo : if no, install package in location
-    let mut deploy_location = DeployLocation::default();
-    let deployment: Deployment = Deployment::new(checksum);
-    deploy_location.add_deployment(deployment);
-
-    let deploy_location_file_content = serializer.serialize(&deploy_location)?;
-
-    filesystem.write_all(lockfile_path, deploy_location_file_content.as_bytes())?;
-
-    // read lockfile to string
-    // parse lockfile
-    // mutate lockfile ( add a deployment checksum )
-    // serialize and write mutated lockfile
-
-    // path_package : C:\\Downloads\static-package-a_0.0.1_ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad_f61f10025ad.packster
-    // path_location : C:\\my-location
-
-    // deploy_path : C:\\my-location\ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad
-
-    Ok(())
-}
-
-// let deploy_location = DeployLocation::default();
-
-// // Check if package is already installed in location
-// if package_is_installed_in_location(&deploy_location) {
-//     // If yes, abort
-//     println!("Package is already installed in location. Aborting.");
-//     return;
-// }
-
-// // If no, install package in location
-// if install_package_in_location(&deploy_location) {
-//     println!("Package installed successfully in location.");
-// } else {
-//     println!("Package installation failed.");
-// }
-
-
-// fn package_is_installed_in_location(location: &DeployLocation) -> bool {
-//     // TODO: Implement logic to check if package is installed in the specified location
-//     // For now, we'll assume the package is never installed and always return false
-//     false
-// }
-
-
-// fn package_is_installed_in_location(location: &DeployLocation) -> bool {
-//     // Check if any deployments exist in the location
-//     for deployment in location.as_slice() {
-//         // TODO: Implement logic to check if the package is installed in this deployment
-//         // For now, we'll assume the package is never installed and continue iterating
-//         // through the deployments.
-//     }
-//     // If we've iterated through all the deployments and haven't found the package, it's not installed.
-//     false
-// }

--- a/packster-core/src/path.rs
+++ b/packster-core/src/path.rs
@@ -91,12 +91,14 @@ impl <T: AsRef<Path>>AsRef<Path> for Absolute<T> {
     fn as_ref(&self) -> &Path { self.0.as_ref() }
 }
 
+impl From<Absolute<PathBuf>> for PathBuf {
+    fn from(value: Absolute<PathBuf>) -> Self {
+        value.0
+    }
+}
+
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct Relative<T: AsRef<Path>>(T);
-
-impl <T: AsRef<Path>>AsRef<Path> for Relative<T> {
-    fn as_ref(&self) -> &Path { self.0.as_ref() }
-}
 
 impl <T: AsRef<Path>>Relative<T> {
     pub fn assume_relative(path: T) -> Self {
@@ -113,6 +115,16 @@ impl <T: AsRef<Path>>Relative<T> {
 
     pub fn to_absolute<P: AsRef<Path>>(&self, base: &Absolute<P>) -> Absolute<PathBuf> {
         base.join(self.0.as_ref())
+    }
+}
+
+impl <T: AsRef<Path>>AsRef<Path> for Relative<T> {
+    fn as_ref(&self) -> &Path { self.0.as_ref() }
+}
+
+impl From<Relative<PathBuf>> for PathBuf {
+    fn from(value: Relative<PathBuf>) -> Self {
+        value.0
     }
 }
 

--- a/packster-core/src/port.rs
+++ b/packster-core/src/port.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, io::{Read, Write}};
 use serde::{de::DeserializeOwned, ser::Serialize};
 
-use crate::{Result, path::{Absolute, NormalizedPathBuf}, Error};
+use crate::{Result, path::{Absolute, NormalizedPathBuf}, Error, domain::Checksum};
 
 pub trait PathExt {
     fn is_ancestor_of<P: AsRef<Path>>(&self, child_path: P) -> bool;
@@ -59,8 +59,7 @@ pub trait Archiver : Sync + Send {
 }
 
 pub trait Digester : Sync + Send {
-    fn generate_checksum<R: Read>(&self, reader: R) -> Result<Vec<u8>>;
-    // fn verify_checksum<R: Read>(&self, reader: R, checksum: &[u8]) -> bool;
+    fn generate_checksum<R: Read>(&self, reader: R) -> Result<Checksum>;
 }
 
 pub trait UniqueIdentifierGenerator : Sync + Send {

--- a/packster-infrastructure/src/in_memory_filesystem.rs
+++ b/packster-infrastructure/src/in_memory_filesystem.rs
@@ -219,8 +219,8 @@ impl Archiver for InMemoryFileSystem {
         Ok(())
     }
 
-    fn extract<F: FileSystem, P1: AsRef<Path>, P2: AsRef<Path>>(&self, filesystem: &F, expand_path: P1, archive_path: P2) -> Result<()> {
-        todo!()
+    fn extract<F: FileSystem, P1: AsRef<Path>, P2: AsRef<Path>>(&self, filesystem: &F, expand_path: Absolute<P1>, archive_path: Absolute<P2>) -> Result<()> {
+        unimplemented!()
     }
 }
 

--- a/packster-infrastructure/src/sha2_digester.rs
+++ b/packster-infrastructure/src/sha2_digester.rs
@@ -1,6 +1,6 @@
 use std::{io::{self, Read}};
 use sha2::{Sha256, Digest};
-use packster_core::port::Digester;
+use packster_core::{port::Digester, domain::Checksum};
 use crate::{ Result, Error };
 
 pub enum Sha2Digester {
@@ -14,12 +14,12 @@ impl Default for Sha2Digester {
 }
 
 impl Digester for Sha2Digester {
-    fn generate_checksum<R: Read>(&self, mut reader: R) -> Result<Vec<u8>> {
+    fn generate_checksum<R: Read>(&self, mut reader: R) -> Result<Checksum> {
         match self {
             Self::Sha256 => {
                 let mut hasher = Sha256::new();
                 io::copy(&mut reader, &mut hasher).map_err(Error::from)?;
-                Ok(hasher.finalize().to_vec())
+                Ok(Checksum::from(hasher.finalize().to_vec()))
             }
         }
     }
@@ -28,12 +28,14 @@ impl Digester for Sha2Digester {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
     use super::*;
 
     #[test]
     fn test_generate_sha256() {
         let digester = Sha2Digester::Sha256;
         let checksum = digester.generate_checksum("This is a long sentence that stands for binary content to be checked".as_bytes()).unwrap();
-        assert_eq!(checksum, hex::decode("564fef4556880e65e5ca00ae35bac4f07fa5f714ea31cc1119f6cdacbc14bcd8").unwrap());
+        assert_eq!(checksum, Checksum::from_str("564fef4556880e65e5ca00ae35bac4f07fa5f714ea31cc1119f6cdacbc14bcd8").unwrap());
     }
 }

--- a/packster-test/Cargo.toml
+++ b/packster-test/Cargo.toml
@@ -8,3 +8,4 @@ packster-core = { path = "../packster-core" }
 packster-infrastructure = { path = "../packster-infrastructure", features=["test"] }
 indoc = "2.0.0"
 hex = "0.4.3"
+base64 = "0.21.0"

--- a/packster-test/src/lib.rs
+++ b/packster-test/src/lib.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod test {
-    use std::{io::Read, path::{PathBuf, Path}, str::FromStr};
+    use std::{io::Read, path::{PathBuf, Path}, str::FromStr };
     use indoc::indoc;
+    use base64::{Engine as _, engine::general_purpose};
 
     use packster_core::{
         port::{
@@ -11,14 +12,19 @@ mod test {
             UniqueIdentifierGenerator,
         },
         Result,
-        operation::{PackRequest, Operation, New, InitLocationRequest},
+        operation::{PackRequest, Operation, New, InitLocationRequest, DeployRequest},
         path::Absolute, LOCKFILE_NAME, domain::Checksum
     };
+
     use packster_infrastructure::{
         InMemoryFileSystem,
         Toml,
-        Json
+        Json, TarballArchiver, Sha2Digester
     };
+
+    fn base64_decode(s: &str) -> Vec<u8> {
+        general_purpose::STANDARD.decode(s).unwrap()
+    }
 
     #[test]
     fn test_static_packing() -> Result<()> {
@@ -68,7 +74,7 @@ mod test {
         let package_path = format!("/repo/static-package-a_0.0.1_ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad.{}.packster", hex::encode(APP_VERSION.as_bytes()));
 
         assert!(filesystem.exists(&package_path));
-        assert!(filesystem.is_file(package_path));
+        assert!(filesystem.is_file(&package_path));
 
         assert!(filesystem_as_archiver.is_file("packster.toml"));
         assert!(filesystem_as_archiver.is_file("hello_world.txt"));
@@ -91,6 +97,54 @@ mod test {
 
         let expected_lockfile_content = "{\"deployments\":[]}";
         assert_eq!(filesystem.read_to_string(expected_lockfile_path)?, expected_lockfile_content);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_deployment_new_package() -> Result<()> {
+        let filesystem = InMemoryFileSystem::default();
+        filesystem.create_dir_recursively("/my/location")?;
+        // Made out of "my-simple-package" stub
+        let package_base64_str =  "H4sIAAAAAAAA/+3WsQ6CMBAG4JtNfIfKLrYiOLn7FqTqoY2FknIafXtlAQOuNjHct7RJx7//5XR+Mh6P5PwTQpO94T1TiYIUArg1pL0QMFG6z3+lc105uqDPC2MxpgfBT3WJr5NB/kptZQYSAph4/nu01onCu1IcHNH7WACbDh2o69/0/R/N/zRLt9z/AD76T67m8k9NrY/XhtDH79FvIayu8Vky2v82ivsfgjlhRaYw6MVOROVz2Ziytrhs/4U+YzSf3dE3xlXts4xlrCJgjDH2/15uvNI0ABIAAA==";
+        let package_bytes = base64_decode(package_base64_str);
+        filesystem.open_write("/my/my-simple-package_0.0.1_d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4.302e312e30.packster")?.write_all(&package_bytes).unwrap();
+
+        let lockfile_path = Path::new("/my/location").join(LOCKFILE_NAME);
+        let empty_lockfile_content = "{\"deployments\":[]}";
+        filesystem.open_write(&lockfile_path)?.write_all(empty_lockfile_content.as_bytes()).unwrap();
+
+        let request = DeployRequest::new(
+            Absolute::assume_absolute(PathBuf::from("/my/my-simple-package_0.0.1_d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4.302e312e30.packster")),
+            Absolute::assume_absolute(PathBuf::from("/my/location")),
+        );
+
+        Operation::new(request, New)
+            .parse_package_path()?
+            .parse_location_lockfile(&filesystem, &Json)?
+            .probe_package_not_deployed_in_location()?
+            .validate_package_checksum(&filesystem, &Sha2Digester::Sha256)?
+            .extract_package(&filesystem, &TarballArchiver)?
+            .update_location_lockfile(&filesystem, &Json)?;
+
+        assert!(filesystem.exists("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4"));
+        assert!(filesystem.is_directory("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4"));
+
+        assert!(filesystem.exists("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/packster.toml"));
+        assert!(filesystem.is_file("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/packster.toml"));
+
+        assert!(filesystem.exists("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_file.txt"));
+        assert!(filesystem.is_file("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_file.txt"));
+        assert_eq!(filesystem.read_to_string("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_file.txt")?, "Hello from top !");
+
+        assert!(filesystem.exists("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_directory"));
+        assert!(filesystem.is_directory("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_directory"));
+
+        assert!(filesystem.exists("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_directory/a_another_file.txt"));
+        assert!(filesystem.is_file("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_directory/a_another_file.txt"));
+        assert_eq!(filesystem.read_to_string("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_directory/a_another_file.txt")?, "Hello from bottom !");
+
+        assert_ne!(filesystem.read_to_string(lockfile_path)?, empty_lockfile_content);
 
         Ok(())
     }

--- a/packster-test/src/lib.rs
+++ b/packster-test/src/lib.rs
@@ -144,7 +144,9 @@ mod test {
         assert!(filesystem.is_file("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_directory/a_another_file.txt"));
         assert_eq!(filesystem.read_to_string("/my/location/d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4/a_directory/a_another_file.txt")?, "Hello from bottom !");
 
-        assert_ne!(filesystem.read_to_string(lockfile_path)?, empty_lockfile_content);
+        let lockfile_content = filesystem.read_to_string(lockfile_path)?;
+        assert_ne!(lockfile_content, empty_lockfile_content);
+        assert!(lockfile_content.contains("d829752c10db8f7a98c939b5418beb0a360c6a6b818830e000f2c5a8dce35af4"));
 
         Ok(())
     }

--- a/packster-test/src/lib.rs
+++ b/packster-test/src/lib.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod test {
-    use std::{io::Read, path::{PathBuf, Path}};
+    use std::{io::Read, path::{PathBuf, Path}, str::FromStr};
     use indoc::indoc;
 
     use packster_core::{
@@ -12,7 +12,7 @@ mod test {
         },
         Result,
         operation::{PackRequest, Operation, New, InitLocationRequest},
-        path::Absolute, LOCKFILE_NAME
+        path::Absolute, LOCKFILE_NAME, domain::Checksum
     };
     use packster_infrastructure::{
         InMemoryFileSystem,
@@ -25,8 +25,8 @@ mod test {
         pub struct DigesterMock;
 
         impl Digester for DigesterMock {
-            fn generate_checksum<R: Read>(&self, _: R) -> Result<Vec<u8>> {
-                Ok(hex::decode("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad").unwrap())
+            fn generate_checksum<R: Read>(&self, _: R) -> Result<Checksum> {
+                Ok(Checksum::from_str("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad").unwrap())
             }
         }
 

--- a/packster-test/stub/my-simple-package/a_directory/a_another_file.txt
+++ b/packster-test/stub/my-simple-package/a_directory/a_another_file.txt
@@ -1,0 +1,1 @@
+Hello from bottom !

--- a/packster-test/stub/my-simple-package/a_file.txt
+++ b/packster-test/stub/my-simple-package/a_file.txt
@@ -1,0 +1,1 @@
+Hello from top !

--- a/packster-test/stub/my-simple-package/packster.toml
+++ b/packster-test/stub/my-simple-package/packster.toml
@@ -1,0 +1,2 @@
+identifier = "my-simple-package"
+version = "0.0.1"


### PR DESCRIPTION
Would close #3 

Implement generic state transformation that can be used by many other specific operations :
- Package parsing from Path
- DeployLocation parsing from Lockfile
- Detection of the deployment state of a package within a location
- Package integrity check

Yet generic, it enforces type system to validate business valid states

Also : 
- provide a decent wrapper type for Checksum
- represents checksum as hexadecimal in lockfile
- rewrite Package filename parsing with regex ( still no error management though )
- provide tar / gz extract implementation